### PR TITLE
Fix SSL Handshake Issue

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,3 +1,6 @@
+import urllib2
+import ssl
+
 PREFIX = '/video/pbskids'
 NAME = 'PBS Kids'
 ART = 'art-default.jpg'
@@ -20,7 +23,10 @@ def Start():
 def MainMenu():
 
     oc = ObjectContainer()
-    json_obj = JSON.ObjectFromURL(PBSKIDS_SHOWS)
+    req = urllib2.Request(PBSKIDS_SHOWS)
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    show_data = urllib2.urlopen(req, context=ssl_context).read()
+    json_obj = JSON.ObjectFromString(show_data)
 
     for item in json_obj['items']:
         title = item['title']
@@ -70,8 +76,11 @@ def VideoPage(type, title, slug, start=0):
 
     oc = ObjectContainer(title2=title)
     end = start+OFFSET
-
-    json_obj = JSON.ObjectFromURL(VIDEO_LIST % (start, end, String.Quote(slug, usePlus=True), type), cacheTime=CACHE_1DAY)
+    
+    req = urllib2.Request(VIDEO_LIST % (start, end, String.Quote(slug, usePlus=True), type))
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    video_list = urllib2.urlopen(req, context=ssl_context).read()
+    json_obj = JSON.ObjectFromString(video_list)
 
     for item in json_obj['items']:
 

--- a/Contents/Services/URL/PBS Kids/ServiceCode.pys
+++ b/Contents/Services/URL/PBS Kids/ServiceCode.pys
@@ -1,3 +1,6 @@
+import urllib2
+import ssl
+
 JSON_URL = 'http://pbskids.org/pbsk/video/api/getVideos/?guid='
 
 ####################################################################################################
@@ -69,14 +72,21 @@ def PlayVideo(url):
             break
     try:    redirect_url = vid_profiles[selected_profile] 
     except: redirect_url = details['videos'][0]['url']
-    m3u8_url = JSON.ObjectFromURL(redirect_url + '?format=json')['url']
+    req = urllib2.Request(redirect_url + '?format=json')
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    data = urllib2.urlopen(req, context=ssl_context).read()
+    json = JSON.ObjectFromString(data)
+    m3u8_url = json['url']
     # Force http for m3u8, https crashing
-    m3u8_url = m3u8_url.replace('https:','http:')
+    # m3u8_url = m3u8_url.replace('https:','http:')
     return IndirectResponse(VideoClipObject, key=HTTPLiveStreamURL(url=m3u8_url))
     
 ####################################################################################################
 def GetJSON(url):
 
     video_id = url.split('guid=')[1]
-    json = JSON.ObjectFromURL(JSON_URL + video_id)
+    req = urllib2.Request(JSON_URL + video_id)
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    data = urllib2.urlopen(req, context=ssl_context).read()
+    json = JSON.ObjectFromString(data)
     return json['items'][0]


### PR DESCRIPTION
PBS Kids has changed their page to now require SSL for all requests. The Plex plugin framework uses an old version of python and urllib2 that has issues with SSL, specifically SNI validation. Previously this issue was bypassed by making requests over http. This is no longer an option.

This work-around creates an SSL context that will not perform validation and uses it for all requests, preventing the handshake errors that the current plugin is getting.

This means that the SSL traffic could be vulnerable to man-in-the-middle attacks, but previously this traffic was entirely unencrypted, so I believe SSL with potential vulnerabilities is an acceptable solution.

I would not recommend using this solution for any plugin that is transmitting passwords or other sensitive information.